### PR TITLE
hotfix: remove unexpected code

### DIFF
--- a/app/Http/Controllers/BlogController.php
+++ b/app/Http/Controllers/BlogController.php
@@ -26,11 +26,6 @@ class BlogController extends Controller
             $blog->content = $content;
         }
 
-        if(!Auth::guest()) {
-            echo Auth::user()->createToken('Token Name')->accessToken;
-            die();
-        }
-
         return view('blog.index', ['blogs' => $blogs]);
     }
 


### PR DESCRIPTION
I added some code to print access_token for dev purpose and forgot to remove. It is not harmful because user can only see their token after login